### PR TITLE
NLS configure issue fix

### DIFF
--- a/stable-patches/auto_configure.patch
+++ b/stable-patches/auto_configure.patch
@@ -1,0 +1,12 @@
+diff --git a/src/auto/configure b/src/auto/configure
+index 5f75592..3073980 100755
+--- a/src/auto/configure
++++ b/src/auto/configure
+@@ -16627,7 +16627,6 @@ printf %s "checking for NLS... " >&6; }
+     have_gettext="no"
+     if test -n "$MSGFMT"; then
+       olibs=$LIBS
+-      LIBS=""
+       cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+ /* end confdefs.h.  */
+ #include <libintl.h>


### PR DESCRIPTION
While checking for NLS the `$LIBS` value is set to empty ("") explicitly. 
But, we need that to link the `gettext` and other libraries.
Hence, removing that. 

Also, this fix is specific to this case as the `ac_link` used in `ac_fn_c_try_link` is using `$LIBS`, and since `$LIBS` was set to empty in this case, i have removed it.