### PR TITLE
Set huge option for features

### DIFF
--- a/buildenv
+++ b/buildenv
@@ -4,11 +4,11 @@ VIM_VERSION="9.2.0350"
 export ZOPEN_BUILD_LINE="STABLE"
 export ZOPEN_CATEGORIES="editor development"
 export ZOPEN_STABLE_URL="https://github.com/vim/vim.git"
-export ZOPEN_STABLE_DEPS="git make zoslib ncurses diffutils coreutils findutils sed gawk check_python lua bash libdio cjson zusage gettext libdio metaldio cjson"
+export ZOPEN_STABLE_DEPS="make zoslib ncurses diffutils coreutils findutils sed gawk check_python lua bash zusage gettext libdio metaldio cjson"
 export ZOPEN_STABLE_TAG="v${VIM_VERSION}"
 export ZOPEN_DEV_URL="https://github.com/vim/vim.git"
 export ZOPEN_DEV_DEPS="git make zoslib ncurses diffutils coreutils findutils sed gawk check_python lua bash libdio cjson zusage gettext libdio metaldio cjson"
-export ZOPEN_EXTRA_CONFIGURE_OPTS="--disable-xattr --with-features=big --with-x=no --enable-gui=no --enable-cscope --enable-terminal --enable-channel --enable-luainterp=dynamic --enable-python3interp=dynamic  --with-compiledby=\${ZOPEN_VENDOR}"
+export ZOPEN_EXTRA_CONFIGURE_OPTS="--disable-xattr --with-features=huge --with-x=no --enable-gui=no --enable-cscope --enable-terminal --enable-channel --enable-luainterp=dynamic --enable-python3interp=dynamic  --with-compiledby=\${ZOPEN_VENDOR}"
 export ZOPEN_CHECK="skip" # TODO: terminal support causes tests to hang
 #export ZOPEN_CHECK="make"
 #export ZOPEN_CHECK_OPTS="test -i"
@@ -16,9 +16,6 @@ export vim_cv_terminfo=yes
 export ZOPEN_RUNTIME_DEPS="ncurses"
 export ZOPEN_EXTRA_CPPFLAGS="-DMOTIF390_MNEMONIC_FIXED=1 -DMODIFIED_BY='\\\""'${ZOPEN_VENDOR}'"\\\"'"
 export ZOPEN_COMP=CLANG
-
-export ZOPEN_EXTRA_CFLAGS="-mzos-target=zosv2r5 -march=z13"
-export ZOPEN_SYSTEM_PREREQS="zos25"
 
 #
 # See patch files for tests currently disabled (hangs, and unsupported screen dump tests)


### PR DESCRIPTION
Removed redundant dependencies . use the new option "huge" for features to enable cscope feature
Fixes #186 